### PR TITLE
Feat: Support multiple CORS origins

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -7,9 +7,22 @@ const app = express();
 const PORT = process.env.PORT || 5001;
 
 // CORS
+const allowedOrigins = (process.env.CORS_ORIGIN || "http://localhost:3000")
+  .split(",")
+  .map((origin) => origin.trim());
+
 app.use(
   cors({
-    origin: process.env.CORS_ORIGIN || "http://localhost:3000",
+    origin: (origin, callback) => {
+      // Allow requests with no origin (like mobile apps or curl requests)
+      if (!origin) return callback(null, true);
+      if (allowedOrigins.indexOf(origin) === -1) {
+        const msg =
+          "The CORS policy for this site does not allow access from the specified Origin.";
+        return callback(new Error(msg), false);
+      }
+      return callback(null, true);
+    },
     methods: ["GET", "POST"],
   }),
 );


### PR DESCRIPTION
This commit updates the server's CORS configuration to support multiple origins.

The `server/server.js` file has been modified to parse a comma-separated list of URLs from the `CORS_ORIGIN` environment variable. This allows the server to accept requests from both local development environments and deployed applications simultaneously.

For example, the `CORS_ORIGIN` variable in the `.env` file can now be set like this: `CORS_ORIGIN=http://localhost:3000,https://some-deployed-app.com`